### PR TITLE
Revert "Added ProtocolVanish v0.1.1 Permissions"

### DIFF
--- a/Main.updb
+++ b/Main.updb
@@ -3516,8 +3516,6 @@ ProtectionStones+protectionstones.view+Allows players the use of /ps view comman
 ProtocolLib+protocol.*+Grants all permissions from the plugin
 ProtocolLib+protocol.admin+Specifies if a hex representation of provided packets should be logged to a file or to console+/packetlog config,/packetlog check,/packetlog version,/packetlog timings,/packetlog listeners
 ProtocolLib+protocol.info+Specifies the users that are notified when there is a new plugin version and that are able to see error reports
-ProtocolVanish+protocolvanish.see.*+Allows you to see vanished players.
-ProtocolVanish+protocolvanish.use.*+ Allows you to use vanish.
 PvPLevels+pvplevels.command.add+Allow to add the Kills/Deaths/Level on an User
 PvPLevels+pvplevels.command.help+Allow to use the /pvplevels help command
 PvPLevels+pvplevels.command.message+Allow to use the /pvplevels message <player> <text> command

--- a/Main.updb
+++ b/Main.updb
@@ -3516,6 +3516,8 @@ ProtectionStones+protectionstones.view+Allows players the use of /ps view comman
 ProtocolLib+protocol.*+Grants all permissions from the plugin
 ProtocolLib+protocol.admin+Specifies if a hex representation of provided packets should be logged to a file or to console+/packetlog config,/packetlog check,/packetlog version,/packetlog timings,/packetlog listeners
 ProtocolLib+protocol.info+Specifies the users that are notified when there is a new plugin version and that are able to see error reports
+ProtocolVanish+protocolvanish.see[number]+Ability to see vanished players (set by level)
+ProtocolVanish+protocolvanish.use[number]+Ability to use vanish (set by level)
 PvPLevels+pvplevels.command.add+Allow to add the Kills/Deaths/Level on an User
 PvPLevels+pvplevels.command.help+Allow to use the /pvplevels help command
 PvPLevels+pvplevels.command.message+Allow to use the /pvplevels message <player> <text> command


### PR DESCRIPTION
Reverts TechsCode/UltraPermissionsDatabase#25
Permissions do not match permission style used in the database as they have variable numbers included. To show that to the user, we use placeholders like [number].